### PR TITLE
Correct version range to support all VS2022 versions

### DIFF
--- a/PowerMode/source.extension.vsixmanifest
+++ b/PowerMode/source.extension.vsixmanifest
@@ -11,13 +11,13 @@
         <Tags>Fun</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[17.0)" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0]" Id="Microsoft.VisualStudio.Pro">
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0]" Id="Microsoft.VisualStudio.Enterprise">
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community">


### PR DESCRIPTION
As explained in #35, this change makes it possible for newer VS2022 versions to install this extension.